### PR TITLE
Feature/router

### DIFF
--- a/src/main/kotlin/com/wintercloud/wintercloudgateway/filter/AuthenticationFilter.kt
+++ b/src/main/kotlin/com/wintercloud/wintercloudgateway/filter/AuthenticationFilter.kt
@@ -1,0 +1,48 @@
+package com.wintercloud.wintercloudgateway.filter
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.cloud.gateway.filter.GatewayFilter
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+
+@Component
+class AuthenticationFilter {
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+
+    fun filter(): GatewayFilter {
+        return GatewayFilter { exchange, chain ->
+            val request = exchange.request
+            val authHeader = request.headers.getFirst(HttpHeaders.AUTHORIZATION)
+
+            if (!hasAuthHeader(authHeader)) {
+                // 인증 실패
+                logger.info {
+                    "Authentication header not found -> " +
+                            "ID: ${request.id}, URI: ${request.uri}, Remote: ${request.remoteAddress}"
+                }
+                return@GatewayFilter exchange.onError()
+            }
+
+            // 인증 성공
+            chain.filter(exchange)
+        }
+    }
+
+    private fun hasAuthHeader(header: String?): Boolean {
+        return !(header.isNullOrEmpty() || !header.startsWith("Bearer "))
+    }
+
+    private fun ServerWebExchange.onError(): Mono<Void?> {
+        val response = this.response
+        response.statusCode = HttpStatus.UNAUTHORIZED
+
+        return response.setComplete()
+    }
+}
+
+

--- a/src/main/kotlin/com/wintercloud/wintercloudgateway/filter/LoggingFilter.kt
+++ b/src/main/kotlin/com/wintercloud/wintercloudgateway/filter/LoggingFilter.kt
@@ -1,0 +1,52 @@
+package com.wintercloud.wintercloudgateway.filter
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.cloud.gateway.filter.GatewayFilterChain
+import org.springframework.cloud.gateway.filter.GlobalFilter
+import org.springframework.core.Ordered
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+
+@Component
+class LoggingFilter : GlobalFilter, Ordered {
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+        private const val START_TIME_KEY = "startTime"
+    }
+
+    override fun filter(exchange: ServerWebExchange, chain: GatewayFilterChain): Mono<Void> {
+        val request = exchange.request
+        exchange.attributes[START_TIME_KEY] = System.currentTimeMillis()
+
+        // 요청 로깅 (Pre-Filter)
+        logger.info {
+            "Request Starting -> " +
+                    "ID: ${request.id}, " +
+                    "URI: ${request.uri}, " +
+                    "Method: ${request.method}, " +
+                    "Remote: ${request.remoteAddress}"
+        }
+
+        // 응답 로깅 (Post-Filter)
+        return chain.filter(exchange).then(
+            Mono.fromRunnable {
+                val response = exchange.response
+                val startTime = exchange.attributes.getOrDefault(START_TIME_KEY, 0L) as Long
+                val duration = System.currentTimeMillis() - startTime
+
+                logger.info {
+                    "Response Finished -> " +
+                            "ID: ${request.id}, " +
+                            "Status: ${response.statusCode}, " +
+                            "Duration: ${duration}ms"
+                }
+            }
+        )
+    }
+
+    override fun getOrder(): Int {
+        return Ordered.HIGHEST_PRECEDENCE
+    }
+}

--- a/src/main/kotlin/com/wintercloud/wintercloudgateway/route/GatewayRoutes.kt
+++ b/src/main/kotlin/com/wintercloud/wintercloudgateway/route/GatewayRoutes.kt
@@ -1,0 +1,38 @@
+package com.wintercloud.wintercloudgateway.route
+
+import com.wintercloud.wintercloudgateway.filter.AuthenticationFilter
+import org.springframework.cloud.gateway.route.RouteLocator
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class GatewayRoutes(
+    private val authenticationFilter: AuthenticationFilter,
+) {
+
+    @Bean
+    fun gatewayRoutes(builder: RouteLocatorBuilder): RouteLocator =
+        builder.routes()
+            .route(
+                routeInfo = RouteInfo.USER_SERVICE,
+                requiresAuth = true
+            )
+            .build()
+
+    fun RouteLocatorBuilder.Builder.route(
+        routeInfo: RouteInfo,
+        requiresAuth: Boolean,
+    ): RouteLocatorBuilder.Builder =
+        this.route(routeInfo.name) { r ->
+            r.path(routeInfo.path)
+                .filters { f ->
+                    if (requiresAuth) {
+                        f.filter(authenticationFilter.filter())
+                    }
+                    f.stripPrefix(routeInfo.stripPrefix)
+                }
+                .uri(routeInfo.uri)
+        }
+
+}

--- a/src/main/kotlin/com/wintercloud/wintercloudgateway/route/RouteInfo.kt
+++ b/src/main/kotlin/com/wintercloud/wintercloudgateway/route/RouteInfo.kt
@@ -1,0 +1,24 @@
+package com.wintercloud.wintercloudgateway.route
+
+/**
+ * Spring Cloud Gateway의 라우트 정보를 타입 안전(type-safe)하게 관리하기 위한 열거형 클래스.
+ * <p>
+ * 각 enum 상수는 하나의 라우트 설정을 나타내며,
+ * 확장 함수와 함께 사용되어 동적으로 라우트를 등록하는 데 쓰입니다.
+ *
+ * @property path 요청 경로가 일치할 때 이 라우트를 활성화시키는 경로 패턴. ("/users/&#42;&#42;")
+ * @property uri 라우팅될 최종 목적지 URI. 서비스 디스커버리의 경우 'lb://서비스이름' 또는 'https://url:port' 형식을 사용합니다.
+ * @property stripPrefix 요청을 전달하기 전에 경로에서 제거할 접두사(prefix)의 개수.
+ */
+enum class RouteInfo(
+    val uri: String,
+    val path: String,
+    val stripPrefix: Int = 0,
+) {
+    // EXAMPLE
+    USER_SERVICE(
+        uri = "lb://USER-SERVICE",
+        path = "/users/**",
+        stripPrefix = 1,
+    );
+}


### PR DESCRIPTION
## ISSUES
- Close #2 

<br>

## ✅ 작업 내용
- `RouteInfo` enum을 통해 라우팅 규칙 정보를 중앙에서 타입 안전하게 관리하도록 설계함.
- `RouteRegistrar` 서비스를 구현하여 라우팅 로직의 역할과 책임을 명확히 분리했음.
- `GatewayRoutes` 설정 클래스를 리팩토링하여 가독성 및 확장성을 개선함.
- `RouteInfo`의 플래그 값을 기반으로 인증 필터가 조건부로 적용되도록 구현함.

<br>

## ⏰ 리뷰 시 확인해야 할 점
- `RouteRegistrar` 서비스로 라우팅 로직을 분리한 아키텍처의 적절성 검토 바람.
- 추후 라우트 개수 증가에 따른 성능 및 확장성 검토 필요.
- `Ordered` 인터페이스로 제어하는 필터 실행 순서의 최적화 방안 검토 요청.

<br>

## ⁉️ 질문이나 우려되는 점
- 향후 `ADMIN` 권한 등 더 복잡한 인가(Authorization) 로직 확장 방안에 대한 논의 필요.

<br>

##  Screenshots
- 해당 없음.

<br>

### PR 올리기 전 체크 리스트
- [x] Merge 대상 브랜치 확인 완료 (`main`)
- [x] PR 라벨 부여 완료 (`feat`)
- [x] 불필요한 코드 및 주석 제거 완료